### PR TITLE
[Phase 2] Step 4: Office document parser

### DIFF
--- a/src/core/office_parser.py
+++ b/src/core/office_parser.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from docx import Document
+from openpyxl import load_workbook
+from pptx import Presentation
+
+
+@dataclass
+class OfficeMetadata:
+    author: Optional[str] = None
+    title: Optional[str] = None
+    created: Optional[str] = None
+
+
+class OfficeParser:
+    """Parse Microsoft Office documents for text and metadata."""
+
+    def parse_docx(self, file_path: Path) -> Dict[str, object]:
+        doc = Document(file_path)
+        paragraphs = [p.text for p in doc.paragraphs if p.text]
+        headings = [
+            p.text for p in doc.paragraphs if p.style.name.startswith("Heading")
+        ]
+        metadata = self.get_document_metadata_docx(doc)
+        return {
+            "paragraphs": paragraphs,
+            "headings": headings,
+            "metadata": metadata.__dict__,
+        }
+
+    def parse_xlsx(self, file_path: Path) -> Dict[str, object]:
+        wb = load_workbook(file_path, data_only=True)
+        sheets: Dict[str, List[List[object]]] = {}
+        for sheet in wb.worksheets:
+            rows = []
+            for row in sheet.iter_rows(values_only=True):
+                rows.append(list(row))
+            sheets[sheet.title] = rows
+        metadata = OfficeMetadata()
+        return {"sheets": sheets, "metadata": metadata.__dict__}
+
+    def parse_pptx(self, file_path: Path) -> Dict[str, object]:
+        pres = Presentation(file_path)
+        slides = []
+        for slide in pres.slides:
+            texts = []
+            for shape in slide.shapes:
+                if hasattr(shape, "text"):
+                    if shape.text:
+                        texts.append(shape.text)
+            slides.append(texts)
+        metadata = OfficeMetadata()
+        return {"slides": slides, "metadata": metadata.__dict__}
+
+    def extract_images(self, file_path: Path, output_dir: Path) -> List[Path]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if file_path.suffix.lower() == ".pptx":
+            pres = Presentation(file_path)
+            images = []
+            for slide in pres.slides:
+                for shape in slide.shapes:
+                    if shape.shape_type == 13:  # picture
+                        image = shape.image
+                        fname = output_dir / image.filename
+                        with open(fname, "wb") as f:
+                            f.write(image.blob)
+                        images.append(fname)
+            return images
+        if file_path.suffix.lower() == ".docx":
+            doc = Document(file_path)
+            images = []
+            rels = doc.part._rels
+            for rel in rels.values():
+                if "image" in rel.reltype:
+                    image_data = rel.target_part.blob
+                    fname = output_dir / Path(rel.target_ref).name
+                    with open(fname, "wb") as f:
+                        f.write(image_data)
+                    images.append(fname)
+            return images
+        return []
+
+    def get_document_metadata_docx(self, doc: Document) -> OfficeMetadata:
+        props = doc.core_properties
+        return OfficeMetadata(
+            author=props.author,
+            title=props.title,
+            created=str(props.created) if props.created else None,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,76 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+import zipfile
+import tarfile
+from typing import Dict
+import io
+from docx import Document
+from openpyxl import Workbook
+from pptx import Presentation
+import pytest
+
+MOCK_DIR = Path(__file__).resolve().parents[1] / "mock_data"
+
+
+def _create_docx(path: Path) -> None:
+    doc = Document()
+    doc.add_heading("Test Document", level=1)
+    doc.add_paragraph("This is a test paragraph.")
+    doc.core_properties.author = "tester"
+    doc.core_properties.title = "mock"
+    doc.save(path)
+
+
+def _create_xlsx(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = "data"
+    wb.create_sheet("Sheet2")
+    wb.save(path)
+
+
+def _create_pptx(path: Path) -> None:
+    prs = Presentation()
+    slide_layout = prs.slide_layouts[0]
+    slide = prs.slides.add_slide(slide_layout)
+    title = slide.shapes.title
+    title.text = "Title"
+    prs.save(path)
+
+
+def _create_zip(path: Path, files: Dict[str, str]) -> None:
+    with zipfile.ZipFile(path, "w") as z:
+        for name, content in files.items():
+            z.writestr(name, content)
+
+
+def _create_tar_gz(path: Path, files: Dict[str, str]) -> None:
+    with tarfile.open(path, "w:gz") as t:
+        for name, content in files.items():
+            tarinfo = tarfile.TarInfo(name)
+            data = content.encode()
+            tarinfo.size = len(data)
+            t.addfile(tarinfo, io.BytesIO(data))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_mock_files() -> None:
+    MOCK_DIR.mkdir(exist_ok=True)
+    if not (MOCK_DIR / "mock_word.docx").exists():
+        _create_docx(MOCK_DIR / "mock_word.docx")
+    if not (MOCK_DIR / "mock_excel.xlsx").exists():
+        _create_xlsx(MOCK_DIR / "mock_excel.xlsx")
+    if not (MOCK_DIR / "mock_powerpoint.pptx").exists():
+        _create_pptx(MOCK_DIR / "mock_powerpoint.pptx")
+    if not (MOCK_DIR / "mock_powerbi.pbix").exists():
+        _create_zip(MOCK_DIR / "mock_powerbi.pbix", {"DataModel/model.bim": "{}"})
+    if not (MOCK_DIR / "mock_tableau.twbx").exists():
+        _create_zip(MOCK_DIR / "mock_tableau.twbx", {"workbook.xml": "<xml/>"})
+    if not (MOCK_DIR / "mock_synapse.zip").exists():
+        _create_zip(MOCK_DIR / "mock_synapse.zip", {"README.md": "synapse"})
+    if not (MOCK_DIR / "mock_archive.zip").exists():
+        _create_zip(MOCK_DIR / "mock_archive.zip", {"file.txt": "hello"})
+    if not (MOCK_DIR / "mock_source.tar.gz").exists():
+        _create_tar_gz(MOCK_DIR / "mock_source.tar.gz", {"src/main.py": "print()"})

--- a/tests/core/test_office_parser.py
+++ b/tests/core/test_office_parser.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from src.core.office_parser import OfficeParser
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
+
+
+def test_parse_docx():
+    parser = OfficeParser()
+    result = parser.parse_docx(DATA_DIR / "mock_word.docx")
+    assert "Test Document" in result["headings"][0]
+    assert "This is a test paragraph." in result["paragraphs"]
+    assert result["metadata"]["author"] == "tester"
+
+
+def test_parse_xlsx():
+    parser = OfficeParser()
+    result = parser.parse_xlsx(DATA_DIR / "mock_excel.xlsx")
+    assert "Sheet1" in result["sheets"]
+    assert result["sheets"]["Sheet1"][0][0] == "data"
+
+
+def test_parse_pptx():
+    parser = OfficeParser()
+    result = parser.parse_pptx(DATA_DIR / "mock_powerpoint.pptx")
+    assert any("Title" in slide for slide in result["slides"])


### PR DESCRIPTION
## Summary
- add OfficeParser with docx/xlsx/pptx support
- generate lightweight mock Office files for tests
- test OfficeParser parsing logic
- remove unused placeholder file

## Testing
- `black -q src tests`
- `pytest -q`