### PR TITLE
[Phase 5] Step 11: add A2A protocol message formats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -826,7 +826,7 @@ A2A Archive Agent
 **Goal**: Complete A2A agent with communication protocols
 
 **A2A Communication Protocol:**
-- [ ] Define standardized request/response message formats
+ - [x] Define standardized request/response message formats
 - [ ] Implement agent capability discovery and advertisement
 - [ ] Create request routing and load balancing logic
 - [ ] Implement authentication and authorization for agent communication

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -859,7 +859,7 @@ A2A Archive Agent
 **Goal**: Complete A2A agent with communication protocols
 
 **A2A Communication Protocol:**
-- [ ] Define standardized request/response message formats
+ - [x] Define standardized request/response message formats
 - [ ] Implement agent capability discovery and advertisement
 - [ ] Create request routing and load balancing logic
 - [ ] Implement authentication and authorization for agent communication

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,5 +1,12 @@
 from .archive_agent import ArchiveAgent
 from .request_interpreter import RequestInterpreter
 from .response_formatter import ResponseFormatter
+from .protocol import AgentRequest, AgentResponse
 
-__all__ = ["ArchiveAgent", "RequestInterpreter", "ResponseFormatter"]
+__all__ = [
+    "ArchiveAgent",
+    "RequestInterpreter",
+    "ResponseFormatter",
+    "AgentRequest",
+    "AgentResponse",
+]

--- a/src/agent/protocol.py
+++ b/src/agent/protocol.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class AgentRequest:
+    """Standardized request structure for A2A communication."""
+
+    file_path: str
+    request_text: str
+    response_format: str = "markdown"
+    agent: str = "unknown"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the request data as a dictionary."""
+        return {
+            "file_path": self.file_path,
+            "request_text": self.request_text,
+            "response_format": self.response_format,
+            "agent": self.agent,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class AgentResponse:
+    """Standardized response structure for A2A communication."""
+
+    status: str
+    message: str
+    data: Any
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the response data as a dictionary."""
+        return {
+            "status": self.status,
+            "message": self.message,
+            "data": self.data,
+            "metadata": self.metadata,
+        }

--- a/tests/agent/test_protocol.py
+++ b/tests/agent/test_protocol.py
@@ -1,0 +1,20 @@
+from src.agent.protocol import AgentRequest, AgentResponse
+
+
+def test_agent_request_to_dict():
+    req = AgentRequest(file_path="file.zip", request_text="extract")
+    data = req.to_dict()
+    assert data["file_path"] == "file.zip"
+    assert data["request_text"] == "extract"
+    assert data["response_format"] == "markdown"
+    assert data["agent"] == "unknown"
+    assert data["metadata"] == {}
+
+
+def test_agent_response_to_dict():
+    resp = AgentResponse(status="success", message="ok", data={"a": 1})
+    data = resp.to_dict()
+    assert data["status"] == "success"
+    assert data["message"] == "ok"
+    assert data["data"] == {"a": 1}
+    assert data["metadata"] == {}


### PR DESCRIPTION
## Summary
- add dataclass-based protocol definitions
- export protocol classes via `src/agent/__init__.py`
- test request and response serialization
- update checklists for Step 11 progress

## Testing
- `pytest -q`