### PR TITLE
[Phase 5] Step 11: implement agent capability registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,14 +827,14 @@ A2A Archive Agent
 
 **A2A Communication Protocol:**
  - [x] Define standardized request/response message formats
-- [ ] Implement agent capability discovery and advertisement
+ - [x] Implement agent capability discovery and advertisement
 - [ ] Create request routing and load balancing logic
 - [ ] Implement authentication and authorization for agent communication
 - [ ] Design error handling and retry mechanisms
 
 **Agent Registry and Discovery:**
-- [ ] Implement agent registration system
-- [ ] Create capability advertisement mechanism
+ - [x] Implement agent registration system
+ - [x] Create capability advertisement mechanism
 - [ ] Design agent health monitoring and status reporting
 - [ ] Implement agent versioning and compatibility checking
 - [ ] Create agent metadata and documentation systems

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -860,14 +860,14 @@ A2A Archive Agent
 
 **A2A Communication Protocol:**
  - [x] Define standardized request/response message formats
-- [ ] Implement agent capability discovery and advertisement
+ - [x] Implement agent capability discovery and advertisement
 - [ ] Create request routing and load balancing logic
 - [ ] Implement authentication and authorization for agent communication
 - [ ] Design error handling and retry mechanisms
 
 **Agent Registry and Discovery:**
-- [ ] Implement agent registration system
-- [ ] Create capability advertisement mechanism
+ - [x] Implement agent registration system
+ - [x] Create capability advertisement mechanism
 - [ ] Design agent health monitoring and status reporting
 - [ ] Implement agent versioning and compatibility checking
 - [ ] Create agent metadata and documentation systems

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -2,6 +2,7 @@ from .archive_agent import ArchiveAgent
 from .request_interpreter import RequestInterpreter
 from .response_formatter import ResponseFormatter
 from .protocol import AgentRequest, AgentResponse
+from .registry import AgentRegistry
 
 __all__ = [
     "ArchiveAgent",
@@ -9,4 +10,5 @@ __all__ = [
     "ResponseFormatter",
     "AgentRequest",
     "AgentResponse",
+    "AgentRegistry",
 ]

--- a/src/agent/registry.py
+++ b/src/agent/registry.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class AgentRegistry:
+    """Simple in-memory registry for agent capabilities."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, Dict[str, Any]] = {}
+
+    def register_agent(self, name: str, capabilities: Dict[str, Any]) -> None:
+        """Register an agent and its capabilities."""
+        self._agents[name] = capabilities
+
+    def get_agent_capabilities(self, name: str) -> Dict[str, Any]:
+        """Return capabilities for the specified agent."""
+        return self._agents.get(name, {})
+
+    def list_agents(self) -> Dict[str, Dict[str, Any]]:
+        """Return all registered agents and their capabilities."""
+        return dict(self._agents)

--- a/tests/agent/test_registry.py
+++ b/tests/agent/test_registry.py
@@ -1,0 +1,16 @@
+from src.agent.registry import AgentRegistry
+
+
+def test_register_and_get_capabilities():
+    registry = AgentRegistry()
+    registry.register_agent("agent1", {"formats": ["zip", "tar"]})
+    assert registry.get_agent_capabilities("agent1") == {"formats": ["zip", "tar"]}
+
+
+def test_list_agents():
+    registry = AgentRegistry()
+    registry.register_agent("agent1", {"formats": ["zip"]})
+    registry.register_agent("agent2", {"formats": ["docx"]})
+    agents = registry.list_agents()
+    assert agents["agent1"]["formats"] == ["zip"]
+    assert agents["agent2"]["formats"] == ["docx"]


### PR DESCRIPTION
## Summary
- implement `AgentRegistry` for capability discovery
- add tests for registry
- export registry in agent package
- mark capability advertisement tasks complete in docs

## Testing
- `pytest -q`