### PR TITLE
[Phase 5] Step 11: add request routing

### DIFF
--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -3,6 +3,7 @@ from .request_interpreter import RequestInterpreter
 from .response_formatter import ResponseFormatter
 from .protocol import AgentRequest, AgentResponse
 from .registry import AgentRegistry
+from .router import RequestRouter
 
 __all__ = [
     "ArchiveAgent",
@@ -11,4 +12,5 @@ __all__ = [
     "AgentRequest",
     "AgentResponse",
     "AgentRegistry",
+    "RequestRouter",
 ]

--- a/src/agent/router.py
+++ b/src/agent/router.py
@@ -1,0 +1,51 @@
+"""Request routing and load balancing for A2A agents."""
+
+from __future__ import annotations
+
+from itertools import cycle
+from typing import Any, Dict, Iterable, Optional
+
+from .registry import AgentRegistry
+
+
+class RequestRouter:
+    """Simple round-robin request router using :class:`AgentRegistry`."""
+
+    def __init__(self, registry: AgentRegistry) -> None:
+        self.registry = registry
+        self._agent_cycle: Optional[Iterable[str]] = None
+
+    def _update_cycle(self) -> None:
+        """Refresh the round-robin cycle when agents change."""
+        agents = list(self.registry.list_agents().keys())
+        self._agent_cycle = cycle(agents) if agents else None
+
+    def register_agent(self, name: str, capabilities: Dict[str, Any]) -> None:
+        """Register an agent and update the routing cycle."""
+        self.registry.register_agent(name, capabilities)
+        self._update_cycle()
+
+    def get_next_agent(self) -> Optional[str]:
+        """Return the next agent in the round-robin cycle."""
+        if self._agent_cycle is None:
+            self._update_cycle()
+        if self._agent_cycle is None:
+            return None
+        return next(self._agent_cycle)
+
+    def route_request(self, request: Dict[str, Any]) -> Optional[str]:
+        """Select an agent to handle the request.
+
+        Parameters
+        ----------
+        request : Dict[str, Any]
+            Parsed request data. Currently unused but reserved for future
+            filtering logic.
+
+        Returns
+        -------
+        Optional[str]
+            Name of the selected agent or ``None`` if no agents are registered.
+        """
+
+        return self.get_next_agent()

--- a/tests/agent/test_router.py
+++ b/tests/agent/test_router.py
@@ -1,0 +1,18 @@
+from src.agent.registry import AgentRegistry
+from src.agent.router import RequestRouter
+
+
+def test_round_robin_routing():
+    registry = AgentRegistry()
+    router = RequestRouter(registry)
+    router.register_agent("agent1", {})
+    router.register_agent("agent2", {})
+
+    order = [router.route_request({}) for _ in range(4)]
+    assert order == ["agent1", "agent2", "agent1", "agent2"]
+
+
+def test_no_agents():
+    registry = AgentRegistry()
+    router = RequestRouter(registry)
+    assert router.route_request({}) is None


### PR DESCRIPTION
## Summary
- add new RequestRouter with round-robin load balancing
- expose RequestRouter in agent package
- test round robin behavior and empty registry handling

## Testing
- `pytest -q`