### PR TITLE
[Phase 5] Step 11: add protocol validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -840,8 +840,8 @@ A2A Archive Agent
 - [ ] Create agent metadata and documentation systems
 
 **Request/Response Validation:**
-- [ ] Implement schema validation for incoming requests
-- [ ] Create response validation and quality checking
+- [x] Implement schema validation for incoming requests
+- [x] Create response validation and quality checking
 - [ ] Design rate limiting and resource management
 - [ ] Implement request tracing and audit logging
 - [ ] Create performance monitoring and metrics collection

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -873,8 +873,8 @@ A2A Archive Agent
 - [ ] Create agent metadata and documentation systems
 
 **Request/Response Validation:**
-- [ ] Implement schema validation for incoming requests
-- [ ] Create response validation and quality checking
+- [x] Implement schema validation for incoming requests
+- [x] Create response validation and quality checking
 - [ ] Design rate limiting and resource management
 - [ ] Implement request tracing and audit logging
 - [ ] Create performance monitoring and metrics collection

--- a/src/agent/protocol.py
+++ b/src/agent/protocol.py
@@ -24,6 +24,28 @@ class AgentRequest:
             "metadata": self.metadata,
         }
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentRequest":
+        """Create and validate an :class:`AgentRequest` from a dictionary."""
+        obj = cls(
+            file_path=data.get("file_path", ""),
+            request_text=data.get("request_text", ""),
+            response_format=data.get("response_format", "markdown"),
+            agent=data.get("agent", "unknown"),
+            metadata=data.get("metadata", {}),
+        )
+        obj.validate()
+        return obj
+
+    def validate(self) -> None:
+        """Validate required fields and supported formats."""
+        if not self.file_path or not isinstance(self.file_path, str):
+            raise ValueError("file_path is required")
+        if not self.request_text or not isinstance(self.request_text, str):
+            raise ValueError("request_text is required")
+        if self.response_format not in {"markdown", "json", "references", "executive"}:
+            raise ValueError("invalid response_format")
+
 
 @dataclass
 class AgentResponse:
@@ -42,3 +64,20 @@ class AgentResponse:
             "data": self.data,
             "metadata": self.metadata,
         }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentResponse":
+        """Create and validate an :class:`AgentResponse` from a dictionary."""
+        obj = cls(
+            status=data.get("status", ""),
+            message=data.get("message", ""),
+            data=data.get("data"),
+            metadata=data.get("metadata", {}),
+        )
+        obj.validate()
+        return obj
+
+    def validate(self) -> None:
+        """Validate response structure."""
+        if self.status not in {"success", "error"}:
+            raise ValueError("status must be 'success' or 'error'")

--- a/tests/agent/test_protocol.py
+++ b/tests/agent/test_protocol.py
@@ -1,3 +1,4 @@
+import pytest
 from src.agent.protocol import AgentRequest, AgentResponse
 
 
@@ -18,3 +19,17 @@ def test_agent_response_to_dict():
     assert data["message"] == "ok"
     assert data["data"] == {"a": 1}
     assert data["metadata"] == {}
+
+
+def test_request_validation():
+    req = AgentRequest.from_dict({"file_path": "f.zip", "request_text": "go"})
+    assert req.file_path == "f.zip"
+    with pytest.raises(ValueError):
+        AgentRequest.from_dict({"file_path": 5, "request_text": ""})
+
+
+def test_response_validation():
+    resp = AgentResponse.from_dict({"status": "success", "message": "ok", "data": None})
+    assert resp.status == "success"
+    with pytest.raises(ValueError):
+        AgentResponse.from_dict({"status": "bad", "message": "", "data": None})


### PR DESCRIPTION
## Summary
- add validation helpers for protocol dataclasses
- extend tests for protocol validation
- mark request/response validation tasks complete

## Testing
- `pytest -q`