### PR TITLE
[Phase 5] Step 11: add health monitoring and robust retry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -830,12 +830,12 @@ A2A Archive Agent
  - [x] Implement agent capability discovery and advertisement
  - [x] Create request routing and load balancing logic
  - [x] Implement authentication and authorization for agent communication
-- [ ] Design error handling and retry mechanisms
+ - [x] Design error handling and retry mechanisms
 
 **Agent Registry and Discovery:**
  - [x] Implement agent registration system
  - [x] Create capability advertisement mechanism
-- [ ] Design agent health monitoring and status reporting
+ - [x] Design agent health monitoring and status reporting
 - [ ] Implement agent versioning and compatibility checking
 - [ ] Create agent metadata and documentation systems
 

--- a/tests/agent/test_registry.py
+++ b/tests/agent/test_registry.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from src.agent.registry import AgentRegistry
 
 
@@ -17,3 +19,13 @@ def test_list_agents_and_status():
     assert agents["agent2"]["formats"] == ["docx"]
     registry.update_agent_status("agent1", "error")
     assert registry.get_agent_status("agent1") == "error"
+
+
+def test_health_monitoring():
+    registry = AgentRegistry()
+    registry.register_agent("agent1", {})
+    assert registry.check_health("agent1", threshold=1) == "online"
+    registry._last_heartbeat["agent1"] -= timedelta(seconds=2)
+    assert registry.check_health("agent1", threshold=1) == "offline"
+    registry.heartbeat("agent1")
+    assert registry.check_health("agent1", threshold=1) == "online"


### PR DESCRIPTION
## Summary
- implement heartbeat-based health monitoring in `AgentRegistry`
- extend `RequestRouter` retry logic and raise `AgentCommunicationError`
- add tests for registry health checks and router retry/heartbeat
- mark completed tasks in `AGENTS.md`

## Testing
- `pytest -q`