### PR TITLE
[Phase 5] Step 11: add protocol docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -854,11 +854,11 @@ A2A Archive Agent
  - [ ] Performance testing under various loads
 
 **Documentation:**
-- [ ] Create A2A protocol specification document
-- [ ] Write integration guide for other agents
-- [ ] Document API endpoints and message formats
-- [ ] Create troubleshooting and debugging guide
-- [ ] Provide example implementations and use cases
+ - [x] Create A2A protocol specification document
+ - [x] Write integration guide for other agents
+ - [ ] Document API endpoints and message formats
+ - [x] Create troubleshooting and debugging guide
+ - [x] Provide example implementations and use cases
 
 **Deliverable**: Complete A2A agent ready for integration with other agents
 

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -887,11 +887,11 @@ A2A Archive Agent
 - [ ] Performance testing under various loads
 
 **Documentation:**
-- [ ] Create A2A protocol specification document
-- [ ] Write integration guide for other agents
-- [ ] Document API endpoints and message formats
-- [ ] Create troubleshooting and debugging guide
-- [ ] Provide example implementations and use cases
+ - [x] Create A2A protocol specification document
+ - [x] Write integration guide for other agents
+ - [ ] Document API endpoints and message formats
+ - [x] Create troubleshooting and debugging guide
+ - [x] Provide example implementations and use cases
 
 **Deliverable**: Complete A2A agent ready for integration with other agents
 

--- a/docs/a2a_protocol.md
+++ b/docs/a2a_protocol.md
@@ -1,0 +1,35 @@
+# A2A Protocol Specification
+
+This document describes how agents communicate using standardized request and response messages.
+
+## Message Structures
+
+### AgentRequest
+- `file_path` – path to the file or archive to analyze
+- `request_text` – natural language request describing the desired operation
+- `response_format` – desired response format (`markdown`, `json`, `references`, `executive`)
+- `agent` – optional identifier of the requesting agent
+- `metadata` – extra request metadata
+
+### AgentResponse
+- `status` – `success` or `error`
+- `message` – human readable summary of the result
+- `data` – parsed content or analysis results
+- `metadata` – additional information such as processing times
+
+Both structures are defined in `src/agent/protocol.py` and include helper methods for validation and conversion.
+
+## Workflow
+1. The requesting agent creates an `AgentRequest` and converts it to a dictionary.
+2. The request is passed to the `RequestRouter`, which selects a suitable agent.
+3. The receiving agent processes the request and returns an `AgentResponse` dictionary.
+4. The router forwards the response back to the requester.
+
+## Error Handling
+Agents should return an `AgentResponse` with `status="error"` and a helpful `message` when processing fails. The router implements basic retry logic and records failures in the audit log.
+
+## Example
+```python
+req = AgentRequest(file_path="mock_data/mock_archive.zip", request_text="list files")
+router.send_request(req.to_dict())
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,14 @@
+# Example Usage
+
+The following example demonstrates how to integrate the archive processing agent into another service.
+
+```python
+from src.agent import ArchiveAgent, AgentRequest
+
+agent = ArchiveAgent()
+request = AgentRequest(file_path="mock_data/mock_archive.zip", request_text="summarize")
+result = agent.process_request(request.file_path, request.request_text)
+print(result["summary"])
+```
+
+For distributed setups, register the agent with an `AgentRegistry` and use a `RequestRouter` to balance requests among multiple agents.

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -1,0 +1,28 @@
+# Integration Guide
+
+This guide explains how to interact with the archive processing agent from other A2A agents or services.
+
+## Registering an Agent
+Use `AgentRegistry` to register agents along with their capabilities and optional handler function.
+```python
+registry = AgentRegistry()
+registry.register_agent("archive-agent", {"formats": ["zip", "docx"]}, handler=my_handler)
+```
+
+## Sending Requests
+Create an `AgentRequest`, convert it to a dictionary, and send it via `RequestRouter`.
+```python
+router = RequestRouter(registry)
+request = AgentRequest(file_path="mock_data/mock_archive.zip", request_text="list files")
+response = router.send_request(request.to_dict())
+```
+
+`send_request` automatically handles basic retries, rate limiting, and audit logging.
+
+## Handling Responses
+`send_request` returns a dictionary matching the `AgentResponse` structure. Check the `status` field and process the `data` accordingly.
+
+## Troubleshooting
+- Ensure the target file path exists and is accessible.
+- Check the audit log via `router.get_audit_log()` for errors.
+- Use `registry.check_health(name)` to verify that agents are online.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,15 @@
+# Troubleshooting and Debugging
+
+This document lists common issues when using the archive processing agent and how to resolve them.
+
+## Common Problems
+- **Unauthorized**: ensure a valid token is passed to the agent or disable authentication in tests.
+- **File Not Found**: verify the `file_path` parameter and check the working directory.
+- **Rate Limit Exceeded**: the router only allows a certain number of requests per minute. Increase the limit or slow down request rate.
+- **Agent Offline**: check the agent status with `registry.check_health()` and ensure the process is running.
+- **Parsing Errors**: if a file cannot be processed, inspect the `message` field in the `AgentResponse` for details.
+
+## Debugging Tips
+- Enable debug logging by setting `LOG_LEVEL=DEBUG` in the environment.
+- Review the audit log via `router.get_audit_log()` to trace recent requests and failures.
+- Use `router.get_traces()` to examine timing information for each request.


### PR DESCRIPTION
## Summary
- document the A2A protocol message structures
- add integration guide, troubleshooting, and example docs
- mark documentation tasks as done in checklists

## Testing
- `pytest -q`