### PR TITLE
[Phase 2] Step 4: expand OfficeParser

### DIFF
--- a/src/core/office_parser.py
+++ b/src/core/office_parser.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from tempfile import TemporaryDirectory
+
 from docx import Document
 from openpyxl import load_workbook
 from pptx import Presentation
@@ -20,69 +22,145 @@ class OfficeParser:
     """Parse Microsoft Office documents for text and metadata."""
 
     def parse_docx(self, file_path: Path) -> Dict[str, object]:
-        doc = Document(file_path)
-        paragraphs = [p.text for p in doc.paragraphs if p.text]
-        headings = [
-            p.text for p in doc.paragraphs if p.style.name.startswith("Heading")
-        ]
-        metadata = self.get_document_metadata_docx(doc)
+        """Parse a Word document and return structured information."""
+        try:
+            doc = Document(file_path)
+        except Exception as exc:  # pragma: no cover - depends on external file
+            raise ValueError(f"Failed to open docx: {exc}") from exc
+
+        paragraphs = []
+        headings: List[str] = []
+        for p in doc.paragraphs:
+            if not p.text:
+                continue
+            para_info = {
+                "text": p.text,
+                "style": p.style.name,
+                "bold": any(run.bold for run in p.runs if run.text),
+                "italic": any(run.italic for run in p.runs if run.text),
+            }
+            paragraphs.append(para_info)
+            if p.style.name.startswith("Heading"):
+                headings.append(p.text)
+
+        tables = []
+        for table in doc.tables:
+            rows = []
+            for row in table.rows:
+                rows.append([cell.text for cell in row.cells])
+            tables.append(rows)
+
+        with TemporaryDirectory() as tmpdir:
+            images = [str(p) for p in self.extract_images(file_path, Path(tmpdir))]
+
+        metadata = self.get_document_metadata(file_path)
         return {
             "paragraphs": paragraphs,
             "headings": headings,
+            "tables": tables,
+            "images": images,
             "metadata": metadata.__dict__,
         }
 
     def parse_xlsx(self, file_path: Path) -> Dict[str, object]:
-        wb = load_workbook(file_path, data_only=True)
-        sheets: Dict[str, List[List[object]]] = {}
+        """Parse an Excel workbook and return structured information."""
+        try:
+            wb = load_workbook(file_path, data_only=True)
+        except Exception as exc:  # pragma: no cover - external
+            raise ValueError(f"Failed to open xlsx: {exc}") from exc
+
+        sheets: Dict[str, Dict[str, object]] = {}
         for sheet in wb.worksheets:
-            rows = []
-            for row in sheet.iter_rows(values_only=True):
-                rows.append(list(row))
-            sheets[sheet.title] = rows
-        metadata = OfficeMetadata()
-        return {"sheets": sheets, "metadata": metadata.__dict__}
+            data_rows: List[List[object]] = []
+            formula_rows: List[List[Optional[str]]] = []
+            comments: List[Dict[str, str]] = []
+            for row in sheet.iter_rows(values_only=False):
+                data_rows.append([cell.value for cell in row])
+                formula_rows.append([cell.value if isinstance(cell.value, str) and cell.value.startswith("=") else None for cell in row])
+                for cell in row:
+                    if cell.comment:
+                        comments.append({"cell": cell.coordinate, "text": cell.comment.text})
+            sheets[sheet.title] = {
+                "data": data_rows,
+                "formulas": formula_rows,
+                "comments": comments,
+            }
+
+        named_ranges = list(wb.defined_names.keys())
+        metadata = self.get_document_metadata(file_path)
+        return {
+            "sheets": sheets,
+            "named_ranges": named_ranges,
+            "metadata": metadata.__dict__,
+        }
 
     def parse_pptx(self, file_path: Path) -> Dict[str, object]:
-        pres = Presentation(file_path)
+        """Parse a PowerPoint presentation."""
+        try:
+            pres = Presentation(file_path)
+        except Exception as exc:  # pragma: no cover - external
+            raise ValueError(f"Failed to open pptx: {exc}") from exc
+
         slides = []
         for slide in pres.slides:
-            texts = []
+            slide_info: Dict[str, object] = {
+                "layout": getattr(slide.slide_layout, "name", "Unknown"),
+                "texts": [],
+                "notes": slide.notes_slide.notes_text_frame.text if slide.has_notes_slide else "",
+            }
             for shape in slide.shapes:
-                if hasattr(shape, "text"):
-                    if shape.text:
-                        texts.append(shape.text)
-            slides.append(texts)
-        metadata = OfficeMetadata()
-        return {"slides": slides, "metadata": metadata.__dict__}
+                if hasattr(shape, "text") and shape.text:
+                    slide_info["texts"].append(shape.text)
+                if hasattr(shape, "table"):
+                    table_data = []
+                    for row in shape.table.rows:
+                        table_data.append([cell.text for cell in row.cells])
+                    slide_info.setdefault("tables", []).append(table_data)
+            slides.append(slide_info)
+
+        with TemporaryDirectory() as tmpdir:
+            images = [str(p) for p in self.extract_images(file_path, Path(tmpdir))]
+
+        metadata = self.get_document_metadata(file_path)
+        return {"slides": slides, "images": images, "metadata": metadata.__dict__}
 
     def extract_images(self, file_path: Path, output_dir: Path) -> List[Path]:
+        """Extract embedded images from Office documents."""
         output_dir.mkdir(parents=True, exist_ok=True)
-        if file_path.suffix.lower() == ".pptx":
+        ext = file_path.suffix.lower()
+        images: List[Path] = []
+
+        if ext == ".pptx":
             pres = Presentation(file_path)
-            images = []
             for slide in pres.slides:
                 for shape in slide.shapes:
-                    if shape.shape_type == 13:  # picture
+                    if getattr(shape, "shape_type", None) == 13:  # picture
                         image = shape.image
                         fname = output_dir / image.filename
                         with open(fname, "wb") as f:
                             f.write(image.blob)
                         images.append(fname)
-            return images
-        if file_path.suffix.lower() == ".docx":
+
+        elif ext == ".docx":
             doc = Document(file_path)
-            images = []
             rels = doc.part._rels
             for rel in rels.values():
                 if "image" in rel.reltype:
-                    image_data = rel.target_part.blob
                     fname = output_dir / Path(rel.target_ref).name
                     with open(fname, "wb") as f:
-                        f.write(image_data)
+                        f.write(rel.target_part.blob)
                     images.append(fname)
-            return images
-        return []
+
+        elif ext == ".xlsx":
+            wb = load_workbook(file_path)
+            for sheet in wb.worksheets:
+                for img in getattr(sheet, "_images", []):
+                    fname = output_dir / Path(img.path).name
+                    with open(fname, "wb") as f:
+                        f.write(img._data())
+                    images.append(fname)
+
+        return images
 
     def get_document_metadata_docx(self, doc: Document) -> OfficeMetadata:
         props = doc.core_properties
@@ -91,3 +169,27 @@ class OfficeParser:
             title=props.title,
             created=str(props.created) if props.created else None,
         )
+
+    def get_document_metadata(self, file_path: Path) -> OfficeMetadata:
+        """Extract common metadata from Office documents."""
+        ext = file_path.suffix.lower()
+        if ext == ".docx":
+            doc = Document(file_path)
+            return self.get_document_metadata_docx(doc)
+        if ext == ".xlsx":
+            wb = load_workbook(file_path, read_only=True)
+            props = wb.properties
+            return OfficeMetadata(
+                author=props.creator,
+                title=props.title,
+                created=str(props.created) if props.created else None,
+            )
+        if ext == ".pptx":
+            pres = Presentation(file_path)
+            props = pres.core_properties
+            return OfficeMetadata(
+                author=props.author,
+                title=props.title,
+                created=str(props.created) if props.created else None,
+            )
+        return OfficeMetadata()

--- a/tests/core/test_office_parser.py
+++ b/tests/core/test_office_parser.py
@@ -9,7 +9,9 @@ def test_parse_docx():
     parser = OfficeParser()
     result = parser.parse_docx(DATA_DIR / "mock_word.docx")
     assert "Test Document" in result["headings"][0]
-    assert "This is a test paragraph." in result["paragraphs"]
+    paragraph_texts = [p["text"] for p in result["paragraphs"]]
+    assert "This is a test paragraph." in paragraph_texts
+    assert "tables" in result
     assert result["metadata"]["author"] == "tester"
 
 
@@ -17,10 +19,10 @@ def test_parse_xlsx():
     parser = OfficeParser()
     result = parser.parse_xlsx(DATA_DIR / "mock_excel.xlsx")
     assert "Sheet1" in result["sheets"]
-    assert result["sheets"]["Sheet1"][0][0] == "data"
+    assert result["sheets"]["Sheet1"]["data"][0][0] == "data"
 
 
 def test_parse_pptx():
     parser = OfficeParser()
     result = parser.parse_pptx(DATA_DIR / "mock_powerpoint.pptx")
-    assert any("Title" in slide for slide in result["slides"])
+    assert any("Title" in slide["texts"][0] for slide in result["slides"])


### PR DESCRIPTION
## Summary
- enhance OfficeParser to return structured information from docx/xlsx/pptx
- improve image extraction and metadata helpers
- adjust tests for new output

## Testing
- `pytest -q`