### PR TITLE
[Phase 2] Step 3: add ConfigManager and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,15 +12,6 @@ venv/
 *.temp
 /mock_data/*.tmp
 /mock_data/extracted_*
-/mock_data/*.zip
-/mock_data/*.tar.gz
-/mock_data/*.tar
-/mock_data/*.pbix
-/mock_data/*.pptx
-/mock_data/*.xlsx
-/mock_data/*.docx
-/mock_data/*.twbx
-/mock_data/*.gz
 
 # Environment and secrets
 .env
@@ -30,3 +21,14 @@ venv/
 
 # Azure specific
 .azure/
+
+# Mock data binaries
+/mock_data/*.zip
+/mock_data/*.tar.gz
+/mock_data/*.tar
+/mock_data/*.pbix
+/mock_data/*.pptx
+/mock_data/*.xlsx
+/mock_data/*.docx
+/mock_data/*.twbx
+/mock_data/*.gz

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -78,3 +78,22 @@ def load_config() -> AppConfig:
         agent_version=os.getenv("AGENT_VERSION", "1.0.0"),
         agent_auth_token=os.getenv("AGENT_AUTH_TOKEN"),
     )
+
+
+class ConfigManager:
+    """Provides access to application configuration values."""
+
+    def __init__(self) -> None:
+        self._config = load_config()
+
+    def get_azure_storage_config(self) -> dict:
+        """Return Azure Storage connection configuration."""
+        return {
+            "account_name": self._config.azure_storage_account_name,
+            "account_key": self._config.azure_storage_account_key,
+            "key_vault_url": self._config.azure_key_vault_url,
+        }
+
+    def get_application_config(self) -> AppConfig:
+        """Return loaded application configuration dataclass."""
+        return self._config

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from src.utils.config import load_config, ConfigError
+from src.utils.config import load_config, ConfigError, ConfigManager
 
 
 def test_load_config_success(monkeypatch):
@@ -16,3 +16,15 @@ def test_load_config_missing(monkeypatch):
     monkeypatch.delenv("LOG_LEVEL", raising=False)
     with pytest.raises(ConfigError):
         load_config()
+
+
+def test_config_manager(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "acc")
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", "key")
+    mgr = ConfigManager()
+    storage_cfg = mgr.get_azure_storage_config()
+    assert storage_cfg["account_name"] == "acc"
+    app_cfg = mgr.get_application_config()
+    assert app_cfg.app_env == "test"


### PR DESCRIPTION
## Summary
- add ConfigManager to manage configuration access
- extend tests for config to cover ConfigManager
- ignore binary mock data

## Testing
- `pytest -q`