### PR TITLE
[Phase 5] Step 11: document API endpoints

### DIFF
--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -887,11 +887,11 @@ A2A Archive Agent
 - [ ] Performance testing under various loads
 
 **Documentation:**
- - [x] Create A2A protocol specification document
- - [x] Write integration guide for other agents
- - [ ] Document API endpoints and message formats
- - [x] Create troubleshooting and debugging guide
- - [x] Provide example implementations and use cases
+- [x] Create A2A protocol specification document
+- [x] Write integration guide for other agents
+- [x] Document API endpoints and message formats
+- [x] Create troubleshooting and debugging guide
+- [x] Provide example implementations and use cases
 
 **Deliverable**: Complete A2A agent ready for integration with other agents
 

--- a/docs/a2a_protocol.md
+++ b/docs/a2a_protocol.md
@@ -33,3 +33,34 @@ Agents should return an `AgentResponse` with `status="error"` and a helpful `mes
 req = AgentRequest(file_path="mock_data/mock_archive.zip", request_text="list files")
 router.send_request(req.to_dict())
 ```
+
+## API Endpoints
+While the archive agent is typically embedded within other systems, it exposes a minimal HTTP interface for direct integration. Implementations may vary, but a reference layout is provided below.
+
+### `POST /process`
+Submit an `AgentRequest` payload as JSON. The service returns an `AgentResponse` object.
+
+```
+POST /process
+Content-Type: application/json
+{
+  "file_path": "mock_data/mock_archive.zip",
+  "request_text": "summarize",
+  "response_format": "json",
+  "agent": "client-1"
+}
+```
+
+### `GET /status`
+Returns simple JSON status including version and health information.
+
+```
+GET /status
+{
+  "agent": "archive-processing-agent",
+  "version": "1.0.0",
+  "status": "online"
+}
+```
+
+These endpoints are optional but recommended for services that need a lightweight HTTP interface in addition to direct A2A communication.


### PR DESCRIPTION
## Summary
- document minimal API endpoints in `docs/a2a_protocol.md`
- mark documentation subtask complete in `DEVELOPMENT_CHECKLIST.md`

## Testing
- `pytest -q`