### PR TITLE
[Phase 6] Step 12: corrupted file tests

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,11 +3,13 @@
 ## Overall Status
 - **Completed Steps**: Phase 1 through Phase 5 Step 11
 - **Remaining Steps**: Phase 6 Step 12 and Phase 6 Step 13
-- **Approximate Completion**: 90%
+- **Approximate Completion**: 92%
 
 ## Latest Update
 - Added test for Key Vault configuration loading in `tests/integration/test_external_systems.py`.
 - Completed Step 12 subtask **Test integration with external systems and APIs**.
+- Added tests for handling corrupted and malformed files across parsers.
+- Completed Step 12 subtask **Test with corrupted and malformed files**.
 
 ## Next Step
-Continue with **Phase 6**, **Step 12**, subtask **Test with corrupted and malformed files**.
+Continue with **Phase 6**, **Step 12**, subtask **Test with extremely large archives (memory and performance limits)**.

--- a/tests/core/test_office_parser.py
+++ b/tests/core/test_office_parser.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from src.core.office_parser import OfficeParser
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
@@ -26,3 +28,27 @@ def test_parse_pptx():
     parser = OfficeParser()
     result = parser.parse_pptx(DATA_DIR / "mock_powerpoint.pptx")
     assert any("Title" in slide["texts"][0] for slide in result["slides"])
+
+
+def test_parse_corrupted_docx(tmp_path):
+    bad = tmp_path / "bad.docx"
+    bad.write_text("invalid")
+    parser = OfficeParser()
+    with pytest.raises(ValueError):
+        parser.parse_docx(bad)
+
+
+def test_parse_corrupted_xlsx(tmp_path):
+    bad = tmp_path / "bad.xlsx"
+    bad.write_text("invalid")
+    parser = OfficeParser()
+    with pytest.raises(ValueError):
+        parser.parse_xlsx(bad)
+
+
+def test_parse_corrupted_pptx(tmp_path):
+    bad = tmp_path / "bad.pptx"
+    bad.write_text("invalid")
+    parser = OfficeParser()
+    with pytest.raises(ValueError):
+        parser.parse_pptx(bad)

--- a/tests/core/test_powerbi_parser.py
+++ b/tests/core/test_powerbi_parser.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from src.core.powerbi_parser import PowerBIParser
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
@@ -10,3 +12,11 @@ def test_parse_pbix():
     result = parser.parse_pbix(DATA_DIR / "mock_powerbi.pbix")
     assert isinstance(result["dax_measures"], list)
     assert isinstance(result["data_sources"], list)
+
+
+def test_parse_corrupted_pbix(tmp_path):
+    bad = tmp_path / "bad.pbix"
+    bad.write_text("invalid")
+    parser = PowerBIParser()
+    with pytest.raises(Exception):
+        parser.parse_pbix(bad)

--- a/tests/core/test_synapse_parser.py
+++ b/tests/core/test_synapse_parser.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from src.core.synapse_parser import SynapseParser
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
@@ -10,3 +12,11 @@ def test_parse_synapse_package():
     result = parser.parse_synapse_package(DATA_DIR / "mock_synapse.zip")
     assert "sql_objects" in result
     assert "notebooks" in result
+
+
+def test_parse_corrupted_synapse(tmp_path):
+    bad = tmp_path / "bad.zip"
+    bad.write_text("invalid")
+    parser = SynapseParser()
+    with pytest.raises(Exception):
+        parser.parse_synapse_package(bad)

--- a/tests/core/test_tableau_parser.py
+++ b/tests/core/test_tableau_parser.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from src.core.tableau_parser import TableauParser
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
@@ -9,3 +11,11 @@ def test_parse_twbx():
     parser = TableauParser()
     result = parser.parse_twbx(DATA_DIR / "mock_tableau.twbx")
     assert isinstance(result["dashboards"], list)
+
+
+def test_parse_corrupted_twbx(tmp_path):
+    bad = tmp_path / "bad.twbx"
+    bad.write_text("invalid")
+    parser = TableauParser()
+    with pytest.raises(Exception):
+        parser.parse_twbx(bad)


### PR DESCRIPTION
## Summary
- extend office, Power BI, Tableau and Synapse parser tests
- add tests covering corrupted and malformed files
- update progress report

## Testing
- `pytest -q`