### PR TITLE
[Phase 6] Step 12: Add password-protected archive test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ venv/
 .DS_Store
 *.tmp
 *.temp
-/mock_data/*.tmp
+/mock_data/*
+!/mock_data/README.md
+!/mock_data/.gitkeep
 /mock_data/extracted_*
 
 # Environment and secrets
@@ -21,14 +23,3 @@ venv/
 
 # Azure specific
 .azure/
-
-# Mock data binaries
-/mock_data/*.zip
-/mock_data/*.tar.gz
-/mock_data/*.tar
-/mock_data/*.pbix
-/mock_data/*.pptx
-/mock_data/*.xlsx
-/mock_data/*.docx
-/mock_data/*.twbx
-/mock_data/*.gz

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,6 +11,7 @@
 - Added tests for handling corrupted and malformed files across parsers.
 - Completed Step 12 subtask **Test with corrupted and malformed files**.
 - Added test for extremely large archives in `tests/integration/test_performance.py`.
+- Added test for password-protected archives in `tests/integration/test_security.py`.
 
 ## Next Step
-Continue with **Phase 6**, **Step 12**, subtask **Test with password-protected and encrypted files**.
+Continue with **Phase 6**, **Step 12**, subtask **Test permission denied and access control scenarios**.

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -1,0 +1,15 @@
+import py7zr
+import pytest
+from pathlib import Path
+
+from src.core.archive_handler import ArchiveHandler
+
+
+def test_extract_password_protected_7z(tmp_path: Path):
+    archive = tmp_path / "secret.7z"
+    with py7zr.SevenZipFile(archive, "w", password="passwd") as z:
+        z.writestr("secret.txt", "hidden")
+
+    handler = ArchiveHandler()
+    with pytest.raises(py7zr.exceptions.PasswordRequired):
+        handler.extract_archive(archive, tmp_path / "out")


### PR DESCRIPTION
## Summary
- ignore generated mock data files
- add integration test for password-protected archives
- update progress report

## Testing
- `pytest -q`