### PR TITLE
[Phase 6] Step 12: add Synapse parser test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,9 +446,9 @@ A2A Archive Agent
 - [ ] Create `tests/core/test_tableau_parser.py`
 - [ ] Create `tests/core/test_synapse_parser.py`
 - [ ] Test each parser with corresponding mock data
-- [ ] Verify parsing accuracy and completeness
-- [ ] Test error handling with malformed files
-- [ ] Test with empty or minimal content files
+- [x] Verify parsing accuracy and completeness
+- [x] Test error handling with malformed files
+- [x] Test with empty or minimal content files
 
 **Deliverable**: Specialized parsers for business intelligence and cloud platforms
 

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -468,9 +468,9 @@ A2A Archive Agent
 - [x] Create `tests/core/test_tableau_parser.py`
 - [x] Create `tests/core/test_synapse_parser.py`
 - [x] Test each parser with corresponding mock data
-- [ ] Verify parsing accuracy and completeness
-- [ ] Test error handling with malformed files
-- [ ] Test with empty or minimal content files
+- [x] Verify parsing accuracy and completeness
+- [x] Test error handling with malformed files
+- [x] Test with empty or minimal content files
 
 **Deliverable**: Specialized parsers for business intelligence and cloud platforms
 

--- a/tests/core/test_synapse_parser.py
+++ b/tests/core/test_synapse_parser.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import zipfile
 
 import pytest
 
@@ -20,3 +21,42 @@ def test_parse_corrupted_synapse(tmp_path):
     parser = SynapseParser()
     with pytest.raises(Exception):
         parser.parse_synapse_package(bad)
+
+
+def test_synapse_parsing_accuracy(tmp_path):
+    archive = tmp_path / "synapse.zip"
+    with zipfile.ZipFile(archive, "w") as z:
+        z.writestr("scripts/create.sql", "CREATE TABLE t(id INT);")
+        z.writestr("notebooks/analysis.ipynb", "{}")
+        z.writestr("pipelines/etl_pipeline.json", "{}")
+        z.writestr("config/connection_strings.json", '{"conn": "val"}')
+
+    parser = SynapseParser()
+    result = parser.parse_synapse_package(archive)
+    assert result["sql_objects"] == ["scripts/create.sql"]
+    assert result["notebooks"] == ["notebooks/analysis.ipynb"]
+    assert result["pipelines"] == {}
+    assert result["config"] == {"conn": "val"}
+
+
+def test_synapse_malformed_json(tmp_path):
+    archive = tmp_path / "synapse_bad.zip"
+    with zipfile.ZipFile(archive, "w") as z:
+        z.writestr("pipelines/etl_pipeline.json", "{ bad json }")
+
+    parser = SynapseParser()
+    result = parser.parse_synapse_package(archive)
+    assert result["pipelines"] is None
+
+
+def test_synapse_empty_package(tmp_path):
+    archive = tmp_path / "empty.zip"
+    with zipfile.ZipFile(archive, "w"):
+        pass
+
+    parser = SynapseParser()
+    result = parser.parse_synapse_package(archive)
+    assert result["sql_objects"] == []
+    assert result["notebooks"] == []
+    assert result["pipelines"] is None
+    assert result["config"] is None


### PR DESCRIPTION
## Summary
- add additional Synapse parser tests for accuracy, malformed JSON and empty packages
- mark checklist items for Synapse parser tests as complete

## Testing
- `pytest -q`