### PR TITLE
[Phase 3] Step 7: Complete summarizer testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,9 +569,9 @@ A2A Archive Agent
 - [x] Create `tests/core/test_content_summarizer.py`
 - [x] Test summary generation with various content types
 - [x] Verify inventory creation accuracy and completeness
-- [ ] Test relationship identification with complex structures
+- [x] Test relationship identification with complex structures
 - [x] Test output formatting for different agent types
-- [ ] Verify quality assessment accuracy
+- [x] Verify quality assessment accuracy
 
 **Deliverable**: Comprehensive content analysis and summarization system
 

--- a/DEVELOPMENT_CHECKLIST.md
+++ b/DEVELOPMENT_CHECKLIST.md
@@ -595,9 +595,9 @@ A2A Archive Agent
 - [x] Create `tests/core/test_content_summarizer.py`
 - [x] Test summary generation with various content types
 - [x] Verify inventory creation accuracy and completeness
-- [ ] Test relationship identification with complex structures
+- [x] Test relationship identification with complex structures
 - [x] Test output formatting for different agent types
-- [ ] Verify quality assessment accuracy
+- [x] Verify quality assessment accuracy
 
 **Deliverable**: Comprehensive content analysis and summarization system
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,6 +17,8 @@
 - Completed Step 12 subtask **Benchmark extraction speed with various archive sizes**.
 - Added test for memory usage during extraction in `tests/integration/test_performance.py`.
 - Completed Step 12 subtask **Measure response times for different request types**.
+- Added tests for relationship identification with complex structures.
+- Added tests verifying summary quality assessment accuracy.
 
 ## Next Step
 Continue with **Phase 6**, **Step 12**, subtask **Test concurrent request handling and resource sharing**.

--- a/src/core/content_summarizer.py
+++ b/src/core/content_summarizer.py
@@ -46,6 +46,13 @@ class ContentSummarizer:
         """Return relationship information if present."""
         return content_data.get("relationships", {})
 
+    def assess_summary_quality(self, summary_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Evaluate summary completeness and return quality metrics."""
+        required = ["total_files", "category_counts", "context"]
+        missing = [field for field in required if field not in summary_data]
+        score = 1.0 - (len(missing) / len(required))
+        return {"score": round(score, 2), "missing": missing}
+
     def format_for_agent_consumption(self, summary_data: Dict[str, Any], output_format: str) -> str:
         """Format summary data for different agent types."""
         if output_format == "json":

--- a/tests/core/test_content_summarizer.py
+++ b/tests/core/test_content_summarizer.py
@@ -26,3 +26,35 @@ def test_format_for_agent_consumption():
     out = summarizer.format_for_agent_consumption(summary, "json")
     assert "total_files" in out
 
+
+def test_relationship_identification_complex():
+    summarizer = ContentSummarizer()
+    data = {
+        "relationships": {
+            "a.csv": ["b.csv", "c.csv"],
+            "b.csv": ["c.csv"],
+            "folder/d.csv": [],
+        }
+    }
+    rel = summarizer.identify_relationships(data)
+    assert rel["a.csv"] == ["b.csv", "c.csv"]
+    assert rel["b.csv"] == ["c.csv"]
+    assert rel["folder/d.csv"] == []
+
+
+def test_assess_summary_quality():
+    summarizer = ContentSummarizer()
+    good = {
+        "total_files": 2,
+        "category_counts": {},
+        "context": "demo",
+    }
+    quality = summarizer.assess_summary_quality(good)
+    assert quality["score"] == 1.0
+    assert not quality["missing"]
+
+    bad = {"total_files": 2}
+    quality = summarizer.assess_summary_quality(bad)
+    assert quality["score"] < 1.0
+    assert "category_counts" in quality["missing"]
+


### PR DESCRIPTION
## Summary
- implement `assess_summary_quality` in `ContentSummarizer`
- add tests for relationship identification and summary quality assessment
- check off corresponding tasks in AGENTS.md and DEVELOPMENT_CHECKLIST.md
- update progress report with latest testing activities

## Testing
- `pytest -q`