### PR TITLE
[Phase 4] Step 8: Add MCP registry and edge case tests

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,3 +12,26 @@ print(result["summary"])
 ```
 
 For distributed setups, register the agent with an `AgentRegistry` and use a `RequestRouter` to balance requests among multiple agents.
+
+## MCP Tool Integration
+
+The `ToolRegistry` allows discovery and invocation of MCP tools. Register the
+`extract_archive_tool` and load its manifest for other agents to discover.
+
+```python
+from src.mcp import extract_archive_tool, ToolRegistry
+from pathlib import Path
+
+registry = ToolRegistry()
+manifest = registry.load_manifest(Path("src/mcp/manifest.json"))
+registry.register_tool("extract_archive", extract_archive_tool, manifest=manifest)
+
+for name, info in registry.discover_tools().items():
+    print(name, info["description"])
+
+result = registry.get_tool("extract_archive")("mock_data/mock_archive.zip")
+print(result["status"])
+```
+
+Different agent types can look up the manifest to understand parameters and
+call the tool directly or via their own frameworks.

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -26,3 +26,21 @@ response = router.send_request(request.to_dict())
 - Ensure the target file path exists and is accessible.
 - Check the audit log via `router.get_audit_log()` for errors.
 - Use `registry.check_health(name)` to verify that agents are online.
+
+## Discovering MCP Tools
+
+MCP tools such as `extract_archive_tool` can be registered with the
+`ToolRegistry`. Agents may query the registry to discover available tools and
+their capabilities.
+
+```python
+from src.mcp import extract_archive_tool, ToolRegistry
+registry = ToolRegistry()
+manifest = registry.load_manifest("src/mcp/manifest.json")
+registry.register_tool("extract_archive", extract_archive_tool, manifest=manifest)
+
+available = registry.discover_tools()
+print(available["extract_archive"]["description"])
+```
+
+Other agents can call the tool via `registry.get_tool(name)(**params)`.

--- a/docs/mcp_tool_usage.md
+++ b/docs/mcp_tool_usage.md
@@ -24,3 +24,17 @@ result = extract_archive_tool("mock_data/mock_archive.zip")
 | `Permission denied. Check file permissions and try again.` | Process lacks permissions | Adjust file permissions |
 | `Corrupted archive file. Unable to extract.` | Archive is damaged or unreadable | Replace or recreate the archive |
 | `Out of disk space during extraction. Free space and retry.` | Temporary directory ran out of space | Free disk space or set `TEMP_STORAGE_PATH` |
+
+## Registry Example
+
+To allow other agents to discover the tool, register it with a `ToolRegistry`:
+
+```python
+from src.mcp import extract_archive_tool, ToolRegistry
+registry = ToolRegistry()
+manifest = registry.load_manifest("src/mcp/manifest.json")
+registry.register_tool("extract_archive", extract_archive_tool, manifest=manifest)
+```
+
+Agents can then inspect `registry.discover_tools()` to learn how to call the
+`extract_archive` tool.

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,0 +1,4 @@
+from .mcp_tool import extract_archive_tool
+from .registry import ToolRegistry
+
+__all__ = ["extract_archive_tool", "ToolRegistry"]

--- a/src/mcp/registry.py
+++ b/src/mcp/registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+import json
+
+
+class ToolRegistry:
+    """Simple registry for MCP tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Dict[str, Any]] = {}
+
+    def register_tool(
+        self,
+        name: str,
+        handler: Callable[..., Dict[str, Any]],
+        *,
+        manifest: Dict[str, Any] | None = None,
+    ) -> None:
+        """Register a tool with optional manifest."""
+        self._tools[name] = {"handler": handler, "manifest": manifest or {}}
+
+    def load_manifest(self, manifest_path: str) -> Dict[str, Any]:
+        """Load a JSON manifest from disk."""
+        path = Path(manifest_path)
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def discover_tools(self) -> Dict[str, Dict[str, Any]]:
+        """Return information about all registered tools."""
+        return {name: data["manifest"] for name, data in self._tools.items()}
+
+    def get_tool(self, name: str) -> Callable[..., Dict[str, Any]]:
+        """Return the registered handler for a tool."""
+        if name not in self._tools:
+            raise KeyError(name)
+        return self._tools[name]["handler"]

--- a/tests/agent/test_archive_agent_edge_cases.py
+++ b/tests/agent/test_archive_agent_edge_cases.py
@@ -1,0 +1,29 @@
+import pytest
+from pathlib import Path
+from src.agent.archive_agent import ArchiveAgent
+from src.agent.authentication import TokenAuthenticator
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
+
+
+def test_unauthorized_request():
+    auth = TokenAuthenticator(valid_tokens=["secret"])
+    agent = ArchiveAgent(authenticator=auth)
+    with pytest.raises(PermissionError):
+        agent.process_request(
+            str(DATA_DIR / "mock_word.docx"), "extract", auth_token="wrong"
+        )
+
+
+def test_file_not_found():
+    agent = ArchiveAgent()
+    with pytest.raises(FileNotFoundError):
+        agent.process_request("/no/such/file.zip", "list", auth_token=None)
+
+
+def test_unsupported_file(tmp_path):
+    file = tmp_path / "data.xyz"
+    file.write_text("data")
+    agent = ArchiveAgent()
+    result = agent.process_request(str(file), "analyze")
+    assert result["content"] == {"unsupported": str(file)}

--- a/tests/integration/test_mcp_framework.py
+++ b/tests/integration/test_mcp_framework.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from src.mcp import extract_archive_tool, ToolRegistry
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "mock_data"
+
+
+def test_mcp_tool_integration():
+    registry = ToolRegistry()
+    manifest = registry.load_manifest("src/mcp/manifest.json")
+    registry.register_tool("extract_archive", extract_archive_tool, manifest=manifest)
+
+    tools = registry.discover_tools()
+    assert "extract_archive" in tools
+
+    result = registry.get_tool("extract_archive")(str(DATA_DIR / "mock_archive.zip"))
+    assert result["status"] == "success"

--- a/tests/mcp/test_tool_registry.py
+++ b/tests/mcp/test_tool_registry.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from src.mcp.registry import ToolRegistry
+from src.mcp.mcp_tool import extract_archive_tool
+
+
+def test_register_and_discover(tmp_path):
+    reg = ToolRegistry()
+    manifest = {"name": "extract", "description": "test"}
+    reg.register_tool("extract", extract_archive_tool, manifest=manifest)
+    tools = reg.discover_tools()
+    assert "extract" in tools
+    assert tools["extract"]["description"] == "test"
+
+
+def test_load_manifest_and_get_tool(tmp_path):
+    reg = ToolRegistry()
+    manifest_file = tmp_path / "manifest.json"
+    manifest_file.write_text('{"name": "extract", "description": "ok"}')
+    manifest = reg.load_manifest(manifest_file)
+    reg.register_tool("extract", extract_archive_tool, manifest=manifest)
+    tool = reg.get_tool("extract")
+    assert tool is extract_archive_tool


### PR DESCRIPTION
## Summary
- implement `ToolRegistry` for registering and discovering MCP tools
- document MCP tool integration examples
- add integration example section in docs
- include registry usage in mcp tool documentation
- add tests for ToolRegistry and MCP framework integration
- add edge case tests for `ArchiveAgent`

## Testing
- `pytest -q`