### PR TITLE
[Phase 6] Step 12: refine setup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 
 # Set up environment variables
+python scripts/setup.py  # interactive CLI helper (prompts to run tests when done)
+# Alternatively open `scripts/setup.html` in a browser for a local web form.
+# If you enter `MANUAL` for the API key the script or page will show a command
+# you can run later to append it to `.env`.
+# You can still create the file manually:
 cp .env.example .env
-# Edit .env with your Azure credentials and settings
+# Edit `.env` with your Azure credentials and settings
 
 # Run tests with mock data
 pytest tests/
@@ -255,7 +260,9 @@ This project is designed for AI-assisted development with OpenAI Codex. To contr
 
 ### Local Development
 1. **Clone and install** (see Quick Start above)
-2. **Configure environment**: Copy `.env.example` to `.env` and add your Azure credentials
+2. **Configure environment**: Run `python scripts/setup.py` or open `scripts/setup.html`
+   to generate your `.env` file (both show a command for the API key if you enter `MANUAL`).
+   The CLI will also offer to run the test suite when finished. You may still copy `.env.example` manually if desired.
 3. **Run tests**: `pytest tests/` (uses mock data, works offline)
 4. **Start development**: Follow the development checklist in `AGENTS.md`
 

--- a/scripts/setup.html
+++ b/scripts/setup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Archive Agent Setup</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+label { display: block; margin-top: 10px; }
+textarea { width: 100%; height: 200px; }
+</style>
+</head>
+<body>
+<h1>Archive Processing Agent Setup</h1>
+<form id="setupForm">
+  <label>Azure Storage Account Name <input type="text" id="AZURE_STORAGE_ACCOUNT_NAME"></label>
+  <label>Azure Storage Account Key <input type="text" id="AZURE_STORAGE_ACCOUNT_KEY"></label>
+  <label>Azure Key Vault URL <input type="text" id="AZURE_KEY_VAULT_URL"></label>
+  <label>Application Environment <input type="text" id="APP_ENV" value="development"></label>
+  <label>Log Level <input type="text" id="LOG_LEVEL" value="INFO"></label>
+  <label>Max File Size MB <input type="number" id="MAX_FILE_SIZE_MB" value="100"></label>
+  <label>Max Archive Files <input type="number" id="MAX_ARCHIVE_FILES" value="1000"></label>
+  <label>Temp Storage Path <input type="text" id="TEMP_STORAGE_PATH" value="/tmp/archive_processing"></label>
+  <label>Agent Name <input type="text" id="AGENT_NAME" value="archive-processing-agent"></label>
+  <label>Agent Version <input type="text" id="AGENT_VERSION" value="1.0.0"></label>
+  <label>API Key (enter MANUAL to skip) <input type="text" id="AGENT_AUTH_TOKEN"></label>
+  <button type="button" onclick="generateEnv()">Generate .env</button>
+</form>
+<h2>.env contents</h2>
+<pre id="output"></pre>
+<h2 id="cmdHeader" style="display:none">Manual Commands</h2>
+<pre id="command" style="display:none"></pre>
+<h2>Next Steps</h2>
+<pre id="tests"></pre>
+<script>
+function generateEnv() {
+  const fields = ['AZURE_STORAGE_ACCOUNT_NAME','AZURE_STORAGE_ACCOUNT_KEY','AZURE_KEY_VAULT_URL','APP_ENV','LOG_LEVEL','MAX_FILE_SIZE_MB','MAX_ARCHIVE_FILES','TEMP_STORAGE_PATH','AGENT_NAME','AGENT_VERSION','AGENT_AUTH_TOKEN'];
+  let env = '';
+  let manual = false;
+  fields.forEach(function(id){
+    const val = document.getElementById(id).value.trim();
+    if(id === 'AGENT_AUTH_TOKEN' && val === 'MANUAL') {
+      manual = true;
+    } else if(val) {
+      env += id + '=' + val + '\n';
+    }
+  });
+  document.getElementById('output').textContent = env;
+
+  if(manual) {
+    document.getElementById('cmdHeader').style.display = 'block';
+    document.getElementById('command').style.display = 'block';
+    document.getElementById('command').textContent = 'echo "AGENT_AUTH_TOKEN=<your_key>" >> .env';
+  } else {
+    document.getElementById('cmdHeader').style.display = 'none';
+    document.getElementById('command').style.display = 'none';
+  }
+
+  document.getElementById('tests').textContent = 'Run tests with: pytest tests/';
+}
+</script>
+</body>
+</html>

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from typing import Dict, Optional
+import subprocess
+
+QUESTIONS = [
+    ("AZURE_STORAGE_ACCOUNT_NAME", "Azure storage account name"),
+    ("AZURE_STORAGE_ACCOUNT_KEY", "Azure storage account key"),
+    ("AZURE_KEY_VAULT_URL", "Azure Key Vault URL"),
+    ("APP_ENV", "Application environment"),
+    ("LOG_LEVEL", "Log level"),
+    ("MAX_FILE_SIZE_MB", "Maximum file size in MB"),
+    ("MAX_ARCHIVE_FILES", "Maximum archive files"),
+    ("TEMP_STORAGE_PATH", "Temporary storage path"),
+    ("AGENT_NAME", "Agent name"),
+    ("AGENT_VERSION", "Agent version"),
+    ("AGENT_AUTH_TOKEN", "API key (enter MANUAL to skip)"),
+]
+
+DEFAULTS: Dict[str, str] = {}
+
+
+def load_defaults(example_path: Path) -> None:
+    """Load defaults from .env.example."""
+    if not example_path.exists():
+        return
+    with example_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, val = line.split("=", 1)
+                DEFAULTS[key] = val
+
+
+def ask(question: str, default: Optional[str] = None) -> str:
+    """Prompt the user for input with optional default."""
+    prompt = f"{question}"
+    if default:
+        prompt += f" [{default}]"
+    prompt += ": "
+    response = input(prompt).strip()
+    return response or (default or "")
+
+
+def main() -> None:
+    load_defaults(Path(".env.example"))
+    values: Dict[str, Optional[str]] = {}
+
+    for var, prompt in QUESTIONS[:-1]:
+        values[var] = ask(prompt, DEFAULTS.get(var))
+
+    # Last question for API key
+    var, prompt = QUESTIONS[-1]
+    key = ask(prompt)
+    if key == "MANUAL":
+        print(f'To add the API key later run:\n    echo "{var}=<your_key>" >> .env')
+        values[var] = None
+    else:
+        values[var] = key
+
+    with open(".env", "w", encoding="utf-8") as f:
+        for var, _ in QUESTIONS:
+            val = values.get(var)
+            if val is not None and val != "":
+                f.write(f"{var}={val}\n")
+
+    print("\n.env configuration written.")
+
+    run = ask("Run tests now? (y/N)", "N")
+    if run.lower() in {"y", "yes"}:
+        print("Running tests...\n")
+        subprocess.run(["pytest", "tests/", "-q"], check=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restore mock data patterns in `.gitignore`
- add missing variables to `.env.example`
- improve README with notes about setup helpers
- update `scripts/setup.html` to display manual API key command and test instructions
- update `scripts/setup.py` to offer running tests

## Testing
- `pytest -q`
- `pytest --cov=src tests/ -q`
